### PR TITLE
fix: expose device setpoint limits on MysaClimate and Number sliders

### DIFF
--- a/custom_components/mysa/climate.py
+++ b/custom_components/mysa/climate.py
@@ -287,6 +287,38 @@ class MysaClimate(
         val = self._get_sticky_value("target_temperature_high", val)
         return self._convert_to_display(float(val)) if val is not None else None
 
+    def _setpoint_limit(self, keys: list[str], fallback_c: float) -> float:
+        """Resolve a min/max setpoint limit reported by the device.
+
+        Mirrors the logic in MysaMin/MaxSetpointNumber.native_value: legacy
+        devices often report mns/mxs/MinSetpoint/MaxSetpoint in centidegrees,
+        ST-V1-0 reports min_setpoint/max_setpoint in degrees. Falls back to
+        the class-level Celsius default if the device exposes no value.
+        """
+        state = self._get_state_data()
+        if isinstance(state, dict):
+            val = self._extract_value(state, keys)
+            if val is not None:
+                val_f = float(val)
+                if val_f > 100:
+                    val_f /= 100.0
+                return cast(float, self._convert_to_display(val_f))
+        return cast(float, self._convert_to_display(fallback_c))
+
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum settable temperature reported by the device."""
+        return self._setpoint_limit(
+            ["min_setpoint", "mns", "MinSetpoint"], self._attr_min_temp
+        )
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum settable temperature reported by the device."""
+        return self._setpoint_limit(
+            ["max_setpoint", "mxs", "MaxSetpoint"], self._attr_max_temp
+        )
+
     @property
     def current_humidity(self) -> float | None:
         """Return humidity."""

--- a/custom_components/mysa/number.py
+++ b/custom_components/mysa/number.py
@@ -357,7 +357,11 @@ class MysaMinSetpointNumber(MysaNumber):
     """Number entity for minimum setpoint limit."""
 
     _attr_native_min_value = 5.0
-    _attr_native_max_value = 30.0
+    # Mysa devices (e.g. INF-V1 in-floor) accept setpoints up to 40 °C even
+    # though the Mysa app's default range is 5–30. Keeping the slider at 30
+    # was rejecting valid values; the cloud API enforces the device's true
+    # range server-side, so a generous slider cap is safe.
+    _attr_native_max_value = 40.0
     _attr_native_step = 0.5
     _attr_native_unit_of_measurement = "°C"
 
@@ -419,7 +423,8 @@ class MysaMaxSetpointNumber(MysaNumber):
     """Number entity for maximum setpoint limit."""
 
     _attr_native_min_value = 5.0
-    _attr_native_max_value = 30.0
+    # See MysaMinSetpointNumber for the rationale on bumping from 30 → 40.
+    _attr_native_max_value = 40.0
     _attr_native_step = 0.5
     _attr_native_unit_of_measurement = "°C"
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -322,6 +322,43 @@ class TestMysaClimateProperties:
 
         assert isinstance(attrs, dict)
 
+    @pytest.mark.asyncio
+    async def test_min_max_temp_from_state(
+        self, hass, mock_coordinator, climate_entity
+    ):
+        """min_temp / max_temp pull device-reported limits, including centidegrees."""
+        await mock_coordinator.async_refresh()
+        climate_entity.hass = hass
+
+        # Degrees (ST-V1-0 style)
+        mock_coordinator.data = {
+            "device1": {"min_setpoint": 7.0, "max_setpoint": 40.0}
+        }
+        assert climate_entity.min_temp == 7.0
+        assert climate_entity.max_temp == 40.0
+
+        # Centidegrees fallback (legacy INF-V1/BB style)
+        mock_coordinator.data = {
+            "device1": {"MinSetpoint": 500, "MaxSetpoint": 4000}
+        }
+        assert climate_entity.min_temp == 5.0
+        assert climate_entity.max_temp == 40.0
+
+    @pytest.mark.asyncio
+    async def test_min_max_temp_fallback_when_keys_missing(
+        self, hass, mock_coordinator, climate_entity
+    ):
+        """Falls back to _attr_min_temp / _attr_max_temp when device omits keys."""
+        await mock_coordinator.async_refresh()
+
+        mock_coordinator.data = {"device1": {}}
+        assert climate_entity.min_temp == 5.0
+        assert climate_entity.max_temp == 30.0
+
+        mock_coordinator.data = None
+        assert climate_entity.min_temp == 5.0
+        assert climate_entity.max_temp == 30.0
+
 
 class TestMysaClimateInfloor:
     """Test dynamic current_temperature for In-Floor devices."""


### PR DESCRIPTION
## Summary

INF-V1 (in-floor) and BB legacy thermostats accept setpoints up to 40 °C, but `MysaClimate` hardcoded `_attr_min_temp = 5.0` / `_attr_max_temp = 30.0` and provided no override of `min_temp` / `max_temp`. The Mysa app showed up to 40 while HA's climate entity rejected anything > 30 with:

```
Provided temperature 40.0 is not valid. Accepted range is 5.0 to 30.0
```

The number-entity siblings (`MysaMinSetpointNumber`, `MysaMaxSetpointNumber`) already read the correct values from `["min_setpoint", "mns", "MinSetpoint"]` / `["max_setpoint", "mxs", "MaxSetpoint"]` with a centidegrees heuristic — `number.master_bathroom_max_setpoint` reports `40.0` correctly today on my INF-V1. But:

1. The climate entity didn't reuse that logic, so `climate.<x>.max_temp` always returned 30.
2. The Number sliders' clamp `_attr_native_max_value = 30.0` blocked picking 40 from the slider in the HA UI even though the underlying API accepts it.

This closes the second half (Issue 2: Temperature range capped at 30 °C) of #16. PR #13 is orthogonal (C/F unit handling) and this change avoids overlapping with it.

## Changes

- **`custom_components/mysa/climate.py`** — Add `min_temp` / `max_temp` properties to `MysaClimate` that reuse the multi-key extraction + centidegrees logic from `MysaMin/MaxSetpointNumber.native_value` via a small `_setpoint_limit` helper. Falls through to the existing `_attr_min_temp` / `_attr_max_temp` when the device exposes no value, so devices that don't report setpoint limits keep their previous behavior.
- **`custom_components/mysa/number.py`** — Bump `_attr_native_max_value` on `MysaMinSetpointNumber` and `MysaMaxSetpointNumber` from 30 → 40 so the slider can reach the device's actual range. The Mysa cloud enforces the device's true range server-side, so a generous slider cap is safe.
- **`tests/test_climate.py`** — Cover the new degrees / centidegrees / fallback branches; 100% coverage maintained.

## Scope

Intentionally narrow:

- `MysaClimate` covers INF-V1 + BB legacy devices (this PR's tested target).
- `MysaSTV10Climate` keeps its existing single-key `min_temp` / `max_temp` override — untouched.
- `MysaACClimate` inherits the new base property and gracefully falls through to its dynamic `_attr_*` populated from `SupportedCaps.tempRange` (existing behavior preserved; verified by `test_ac_climate_limits_dynamic`).

Mirrors the cautious pattern in #13 of leaving untested classes alone.

## Verification

**Hardware:** Mysa INF-V1-0, firmware 3.17.3.1, HA 2026.4.3.

Before the fix, calling `climate.set_temperature` with `temperature: 40, hvac_mode: heat`:

```
HTTP/1.1 500 Internal Server Error
500 Internal Server Error
Server got itself in trouble
```

After the fix loaded into HA, the same call returns `200 OK` with the new state, and `climate.master_bathroom.max_temp` correctly reports `40.0` (from the `MaxSetpoint` centidegrees field already in coordinator data).

**Test suite (matches CI):**

```
$ pytest
1115 passed, 2 errors in 7.88s
Required test coverage of 100% reached. Total coverage: 100.00%

$ pylint custom_components/mysa
Your code has been rated at 10.00/10
```

The 2 errors (`test_s1_climate_fallback`, `test_api_setup_mocked`) reproduce identically on `main` without my changes — both pre-existing, unrelated to this PR.

Closes #16 (Issue 2 only — Issue 1's MQTT `1005` failure is a separate problem).