### PR TITLE
Add schedule control: Schedule/Hold presets + hold_until service

### DIFF
--- a/custom_components/mysa/climate.py
+++ b/custom_components/mysa/climate.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 # too-many-lines: Handles multiple climate device types (Baseboard, AC, ST-V1-0) in one file.
 # too-many-public-methods: Climate entities require many property overrides.
 import asyncio
+from datetime import datetime
 import logging
 import time
 from typing import Any, cast
+
+import voluptuous as vol
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
@@ -28,12 +31,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util import dt as dt_util
 
 from . import MysaData
 from .const import (
@@ -56,6 +61,11 @@ from .const import (
     AC_MODE_OFF,
     AC_SWING_MODES,
     DOMAIN,
+    PRESET_HOLD,
+    PRESET_SCHEDULE,
+    SCHEDULE_MODE_FOLLOWING,
+    SCHEDULE_MODE_HOLD,
+    SERVICE_HOLD_UNTIL,
 )
 from .device import MysaDeviceLogic
 from .mysa_api import MysaApi
@@ -97,6 +107,18 @@ async def async_setup_entry(
 
     async_add_entities(entities)
 
+    # Register the hold-until entity service (a timed hold can't be a preset, since
+    # it needs a timestamp argument). Applies to the climate platform's entities.
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_HOLD_UNTIL,
+        {
+            vol.Required("until"): cv.datetime,
+            vol.Optional("temperature"): vol.Coerce(float),
+        },
+        "async_hold_until",
+    )
+
 
 class MysaClimate(
     ClimateEntity,
@@ -108,7 +130,9 @@ class MysaClimate(
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TURN_OFF
         | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.PRESET_MODE
     )
+    _attr_preset_modes = [PRESET_SCHEDULE, PRESET_HOLD]
     _attr_min_temp = 5.0
     _attr_max_temp = 30.0
     _attr_precision = PRECISION_TENTHS
@@ -448,6 +472,23 @@ class MysaClimate(
         """Return supported hvac modes."""
         return [HVACMode.HEAT, HVACMode.OFF]
 
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset: following the schedule vs. an indefinite hold.
+
+        Read from the device's reported ScheduleMode (1=following, 2=indefinite hold);
+        falls back to None when the device hasn't reported it yet.
+        """
+        state = self._get_state_data()
+        sched = self._extract_value(state, ["ScheduleMode"]) if state else None
+        if sched == SCHEDULE_MODE_HOLD:
+            result: str | None = PRESET_HOLD
+        elif sched == SCHEDULE_MODE_FOLLOWING:
+            result = PRESET_SCHEDULE
+        else:
+            result = None
+        return self._get_sticky_value("preset_mode", result)
+
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         temp = kwargs.get(ATTR_TEMPERATURE)
@@ -495,6 +536,51 @@ class MysaClimate(
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_hvac_mode_failed",
+                translation_placeholders={"error": str(e)},
+            ) from e
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set preset mode: follow the schedule or hold indefinitely."""
+        try:
+            self._set_sticky_value("preset_mode", preset_mode)
+            if preset_mode == PRESET_SCHEDULE:
+                await self._api.resume_schedule(self._device_id)
+            elif preset_mode == PRESET_HOLD:
+                await self._api.set_hold(self._device_id)
+            else:
+                raise ValueError(f"Unsupported preset_mode: {preset_mode}")
+            self.async_write_ha_state()
+        except Exception as e:
+            if "preset_mode" in self._pending_updates:
+                del self._pending_updates["preset_mode"]
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_preset_mode_failed",
+                translation_placeholders={"error": str(e)},
+            ) from e
+
+    async def async_hold_until(
+        self, until: datetime, temperature: float | None = None
+    ) -> None:
+        """Service handler: hold (optionally at a temperature) until a time, then resume the schedule."""
+        try:
+            ts = int(dt_util.as_timestamp(until))
+            temp_c: float | None = None
+            if temperature is not None:
+                temp_c = round(self._convert_from_display(float(temperature)) * 2) / 2
+                self._set_sticky_value(
+                    "target_temperature", self._convert_to_display(temp_c)
+                )
+            await self._api.hold_until(self._device_id, ts, temp_c)
+            self.async_write_ha_state()
+        except Exception as e:
+            if "target_temperature" in self._pending_updates:
+                del self._pending_updates["target_temperature"]
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="hold_until_failed",
                 translation_placeholders={"error": str(e)},
             ) from e
 

--- a/custom_components/mysa/climate.py
+++ b/custom_components/mysa/climate.py
@@ -117,6 +117,9 @@ async def async_setup_entry(
             vol.Optional("temperature"): vol.Coerce(float),
         },
         "async_hold_until",
+        # Schedule/hold control only applies to the baseboard/floor thermostats that
+        # expose the schedule presets; AC and ST-V1-0 entities don't support it.
+        required_features=[ClimateEntityFeature.PRESET_MODE],
     )
 
 

--- a/custom_components/mysa/const.py
+++ b/custom_components/mysa/const.py
@@ -134,3 +134,27 @@ SENSOR_MODES = {
 }
 
 SENSOR_MODES_REVERSE = {v: k for k, v in SENSOR_MODES.items()}
+
+
+# =============================================================================
+# Schedule / Hold control (msg:44 "ho"/"tm" semantics)
+# =============================================================================
+# A Mysa thermostat is either following its schedule or on a manual hold. The
+# hold behaviour is expressed in the command's "ho"/"tm" fields:
+#   {"ho": 1, "tm": -1}        -> follow the schedule (resume at next change)
+#   {"ho": 1, "tm": <unixts>}  -> hold until a time, then resume the schedule
+#   {"ho": 2, "tm": -1}        -> hold indefinitely, until explicitly changed
+# (Setting a bare setpoint holds only until the next scheduled change.)
+
+PRESET_SCHEDULE = "Schedule"
+"""Climate preset: follow the device's schedule (clear any manual hold)."""
+
+PRESET_HOLD = "Hold"
+"""Climate preset: hold the current setting indefinitely, until explicitly changed."""
+
+# Values reported in the device's "ScheduleMode" state field
+SCHEDULE_MODE_FOLLOWING = 1
+SCHEDULE_MODE_HOLD = 2
+
+SERVICE_HOLD_UNTIL = "hold_until"
+"""Service: hold (optionally at a temperature) until a time, then resume the schedule."""

--- a/custom_components/mysa/mysa_api.py
+++ b/custom_components/mysa/mysa_api.py
@@ -870,6 +870,67 @@ class MysaApi:
         # 2. No additional notification needed for direct MQTT commands.
         # The device will echo its state automatically.
 
+    async def resume_schedule(self, device_id: str) -> None:
+        """Resume following the device's schedule, clearing any manual hold (ho=1, tm=-1)."""
+        self._last_command_time[device_id] = time.time()
+        self._update_state_cache(
+            device_id, {"ScheduleMode": 1, "Timestamp": int(time.time())}
+        )
+        if self.coordinator_callback:
+            await self.coordinator_callback()
+
+        device = self.devices.get(device_id)
+        payload_type = MysaDeviceLogic.get_payload_type(
+            device, self.upgraded_lite_devices
+        )
+        body = {"cmd": [{"ho": 1, "tm": -1}], "type": payload_type, "ver": 1}
+        await self.realtime.send_command(device_id, body, self.client.user_id)
+
+    async def set_hold(self, device_id: str) -> None:
+        """Hold the current setting indefinitely, until explicitly changed (ho=2, tm=-1)."""
+        self._last_command_time[device_id] = time.time()
+        self._update_state_cache(
+            device_id, {"ScheduleMode": 2, "Timestamp": int(time.time())}
+        )
+        if self.coordinator_callback:
+            await self.coordinator_callback()
+
+        device = self.devices.get(device_id)
+        payload_type = MysaDeviceLogic.get_payload_type(
+            device, self.upgraded_lite_devices
+        )
+        body = {"cmd": [{"ho": 2, "tm": -1}], "type": payload_type, "ver": 1}
+        await self.realtime.send_command(device_id, body, self.client.user_id)
+
+    async def hold_until(
+        self, device_id: str, until: int, temperature: float | None = None
+    ) -> None:
+        """Hold (optionally at `temperature` °C) until Unix time `until`, then resume the schedule (ho=1, tm=until)."""
+        self._last_command_time[device_id] = time.time()
+        cache: dict[str, Any] = {"ScheduleMode": 1, "Timestamp": int(time.time())}
+        cmd: dict[str, Any] = {"ho": 1, "tm": int(until)}
+        if temperature is not None:
+            target_val = float(temperature)
+            cmd.update({"sp": target_val, "stpt": target_val, "a_sp": target_val})
+            cache.update(
+                {
+                    "SetPoint": target_val,
+                    "sp": target_val,
+                    "stpt": target_val,
+                    "a_sp": target_val,
+                }
+            )
+        self._update_state_cache(device_id, cache)
+        if self.coordinator_callback:
+            await self.coordinator_callback()
+
+        device = self.devices.get(device_id)
+        payload_type = MysaDeviceLogic.get_payload_type(
+            device, self.upgraded_lite_devices
+        )
+        body = {"cmd": [cmd], "type": payload_type, "ver": 1}
+        await self.realtime.send_command(device_id, body, self.client.user_id)
+
     async def notify_settings_changed(self, device_id: str) -> None:
         """Notify device to check cloud settings (MsgType 6)."""
         timestamp = int(time.time())

--- a/custom_components/mysa/services.yaml
+++ b/custom_components/mysa/services.yaml
@@ -1,0 +1,28 @@
+hold_until:
+  name: Hold until
+  description: >-
+    Hold the thermostat (optionally at a given temperature) until a specific
+    time, then automatically resume its schedule.
+  target:
+    entity:
+      integration: mysa
+      domain: climate
+  fields:
+    until:
+      name: Until
+      description: When the hold should expire and the schedule resume.
+      required: true
+      selector:
+        datetime:
+    temperature:
+      name: Temperature
+      description: >-
+        Optional target temperature to hold, in the thermostat's display unit.
+        If omitted, the current setpoint is held.
+      required: false
+      selector:
+        number:
+          min: 5
+          max: 86
+          step: 0.5
+          mode: box

--- a/custom_components/mysa/strings.json
+++ b/custom_components/mysa/strings.json
@@ -62,6 +62,20 @@
         "downgrade_lite_device": {
             "name": "Revert Lite Device",
             "description": "Reverts a Mysa thermostat from Full features back to Lite (Downgrade)."
+        },
+        "hold_until": {
+            "name": "Hold until",
+            "description": "Hold the thermostat (optionally at a given temperature) until a specific time, then automatically resume its schedule.",
+            "fields": {
+                "until": {
+                    "name": "Until",
+                    "description": "When the hold should expire and the schedule resume."
+                },
+                "temperature": {
+                    "name": "Temperature",
+                    "description": "Optional target temperature to hold, in the thermostat's display unit. If omitted, the current setpoint is held."
+                }
+            }
         }
     },
     "issues": {
@@ -308,6 +322,12 @@
         },
         "set_hvac_mode_failed": {
             "message": "Failed to set HVAC mode: {error}"
+        },
+        "set_preset_mode_failed": {
+            "message": "Failed to set preset mode: {error}"
+        },
+        "hold_until_failed": {
+            "message": "Failed to hold until the requested time: {error}"
         },
         "set_ac_hvac_mode_failed": {
             "message": "Failed to set AC HVAC mode: {error}"

--- a/custom_components/mysa/translations/en.json
+++ b/custom_components/mysa/translations/en.json
@@ -276,6 +276,12 @@
         "set_hvac_mode_failed": {
             "message": "Failed to set HVAC mode: {error}"
         },
+        "set_preset_mode_failed": {
+            "message": "Failed to set preset mode: {error}"
+        },
+        "hold_until_failed": {
+            "message": "Failed to hold until the requested time: {error}"
+        },
         "set_sensor_mode_failed": {
             "message": "Failed to set sensor mode: {error}"
         },
@@ -351,6 +357,20 @@
         "downgrade_lite_device": {
             "description": "Reverts a Mysa thermostat from Full features back to Lite (Downgrade).",
             "name": "Revert Lite Device"
+        },
+        "hold_until": {
+            "description": "Hold the thermostat (optionally at a given temperature) until a specific time, then automatically resume its schedule.",
+            "name": "Hold until",
+            "fields": {
+                "until": {
+                    "name": "Until",
+                    "description": "When the hold should expire and the schedule resume."
+                },
+                "temperature": {
+                    "name": "Temperature",
+                    "description": "Optional target temperature to hold, in the thermostat's display unit. If omitted, the current setpoint is held."
+                }
+            }
         },
         "upgrade_lite_device": {
             "description": "Upgrades a Mysa Lite thermostat to Full features (Magic Upgrade).",


### PR DESCRIPTION
The integration could set a temperature but couldn't tell a thermostat to **follow / resume its schedule**. This adds that, reusing the existing `msg:44` command plumbing (`realtime.send_command` + `get_payload_type`).

**Climate presets** (on baseboard/floor entities — the `AC` and `ST-V1-0` subclasses override `supported_features`, so they're unaffected):
- **Schedule** — resume following the schedule (`{ho:1, tm:-1}`)
- **Hold** — hold indefinitely, until changed (`{ho:2, tm:-1}`)
- `preset_mode` is read back from the device's `ScheduleMode` (1 = following, 2 = hold).

**`hold_until` service** — hold (optionally at a temperature) until a given time, then auto-resume the schedule (`{ho:1, tm:<unixtime>}`). It's a service rather than a preset because it needs a timestamp argument, and it's gated on `ClimateEntityFeature.PRESET_MODE` so it's only offered on schedule-capable thermostats.

New `mysa_api` methods: `resume_schedule()`, `set_hold()`, `hold_until()`. Adds `services.yaml` and matching `strings.json` / `en.json` entries. A bare setpoint change still creates a temporary hold (until the next scheduled change) — unchanged.

**Tested live** against `BB-V2-0` and `INF-V1-0` devices: presets and the service drive the device, and `ScheduleMode` read-back reflects the hold state.

**Known limitation:** a *temporary* setpoint-hold isn't distinctly surfaced — Mysa's cloud state doesn't expose it (it reports `ScheduleMode: 1`, same as following schedule), so it appears as the "Schedule" preset. Distinguishing it would require fetching and comparing the schedule, which is out of scope here.
