### PR TITLE
fix: recover from silent MQTT freeze (data-only watchdog)

### DIFF
--- a/custom_components/mysa/const.py
+++ b/custom_components/mysa/const.py
@@ -22,6 +22,12 @@ MQTT_KEEPALIVE: int = 60
 MQTT_PING_INTERVAL: int = 25
 """Interval between MQTT PINGREQ packets (less than keepalive)"""
 
+MQTT_DATA_TIMEOUT: int = 600
+"""Max seconds without an inbound PUBLISH (telemetry) before the connection is
+considered a zombie and force-reconnected. PINGRESP/PUBACK traffic does NOT
+reset this timer, so a silently dropped subscription (data stops while the
+socket and MQTT keepalive stay alive) is detected and recovered."""
+
 MQTT_USER_AGENT: str = "okhttp/4.11.0"
 """User-Agent header matching Mysa Android app"""
 

--- a/custom_components/mysa/mysa_api.py
+++ b/custom_components/mysa/mysa_api.py
@@ -137,12 +137,14 @@ class MysaApi:
         if not self.realtime._mqtt_connected.is_set():
             return "Connecting"
 
-        # Check staleness (5 minutes)
-        last_pkt = self.realtime.last_packet_time
-        if last_pkt == 0:
+        # Check staleness against actual telemetry, not keepalive traffic (5 minutes).
+        # Using last_data_time here means a silently dropped subscription surfaces as
+        # "Stale" instead of hiding behind PINGRESP keepalive.
+        last_data = self.realtime.last_data_time
+        if last_data == 0:
             return "Starting"
 
-        if time.time() - last_pkt > 300:
+        if time.time() - last_data > 300:
             return "Stale"
 
         return "Running"

--- a/custom_components/mysa/realtime.py
+++ b/custom_components/mysa/realtime.py
@@ -12,7 +12,7 @@ import websockets
 from homeassistant.core import HomeAssistant
 
 from . import mqtt
-from .const import MQTT_PING_INTERVAL
+from .const import MQTT_DATA_TIMEOUT, MQTT_PING_INTERVAL
 from .mysa_mqtt import (
     build_subscription_topics,
     connect_websocket,
@@ -56,7 +56,11 @@ class MysaRealtime:
         self._stv10_devices: list[str] = []  # List of ST-V1-0 device IDs
         self._use_batch = False  # Disabled in Core (not needed for history)
         self._batch_retry_time = 0.0
-        self._last_packet_time = 0.0  # Time of last received MQTT packet
+        self._last_packet_time = 0.0  # Time of last received MQTT packet (any type)
+        # Time of last inbound PUBLISH (actual device telemetry). Kept distinct
+        # from _last_packet_time so PINGRESP/PUBACK traffic can't mask a dead
+        # subscription stream (the silent-freeze bug).
+        self._last_data_time = 0.0
 
     @property
     def is_running(self) -> bool:
@@ -65,8 +69,13 @@ class MysaRealtime:
 
     @property
     def last_packet_time(self) -> float:
-        """Return timestamp of last received packet."""
+        """Return timestamp of last received packet (any type, incl. PINGRESP)."""
         return self._last_packet_time
+
+    @property
+    def last_data_time(self) -> float:
+        """Return timestamp of last inbound PUBLISH (device telemetry)."""
+        return self._last_data_time
 
     @property
     def is_connected(self) -> bool:
@@ -200,7 +209,9 @@ class MysaRealtime:
         try:
             await self._perform_mqtt_handshake(ws)
             self._mqtt_connected.set()
-            self._last_packet_time = time.time()  # Initialize on connect
+            now = time.time()
+            self._last_packet_time = now  # Initialize on connect
+            self._last_data_time = now  # Grace period before data watchdog can fire
             await self._run_mqtt_loop(ws)
         except Exception as listen_error:
             # If we failed during subscription/handshake specifically, and batch was on,
@@ -339,6 +350,8 @@ class MysaRealtime:
                     pkt = parse_mqtt_packet(msg)
                     if pkt:
                         if isinstance(pkt, mqtt.PublishPacket):
+                            # Actual device telemetry: refresh the data watchdog.
+                            self._last_data_time = time.time()
                             await self._process_mqtt_publish(pkt)
                         elif (
                             hasattr(pkt, "pkt_type")
@@ -373,11 +386,17 @@ class MysaRealtime:
                     _LOGGER.error("Failed to send keepalive ping: %s", e, exc_info=True)
                     raise
 
-            # Check for silent (zombie) connection: If no packet received for 10 minutes,
-            # force a reconnect. AWS session expiry is 12h, but we want faster recovery.
-            if time.time() - self._last_packet_time > 600:
+            # Check for silent (zombie) connection: if no device telemetry (PUBLISH)
+            # has arrived for MQTT_DATA_TIMEOUT, force a reconnect. We track data
+            # separately from _last_packet_time because MQTT keepalive PINGRESP (and
+            # PUBACK) keep the socket "alive" even when the subscription stream has
+            # silently died - the classic frozen-readings failure. AWS session expiry
+            # is 12h, but we want faster recovery.
+            if time.time() - self._last_data_time > MQTT_DATA_TIMEOUT:
                 _LOGGER.warning(
-                    "MQTT heartbeat watchdog: No traffic received for 600s, forcing reconnection..."
+                    "MQTT data watchdog: No device telemetry received for %ds "
+                    "(keepalive still alive), forcing reconnection...",
+                    MQTT_DATA_TIMEOUT,
                 )
                 raise RuntimeError("MQTT silence watchdog triggered")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1804,10 +1804,10 @@ class TestApiRestoredConsolidated:
         assert api.mqtt_status == "Connecting"
 
         api.realtime._mqtt_connected.is_set = MagicMock(return_value=True)
-        api.realtime.last_packet_time = 0
+        api.realtime.last_data_time = 0
         assert api.mqtt_status == "Starting"
 
-        api.realtime.last_packet_time = 100 # very old
+        api.realtime.last_data_time = 100 # very old
         with patch("time.time", return_value=1000):
             assert api.mqtt_status == "Stale"
 
@@ -1991,7 +1991,7 @@ async def test_mqtt_status_stale():
     api.realtime._mqtt_connected.is_set.return_value = True
 
     now = time.time()
-    type(api.realtime).last_packet_time = PropertyMock(return_value=now - 601)
+    type(api.realtime).last_data_time = PropertyMock(return_value=now - 601)
 
     mock_hass = MagicMock()
     mock_hass.async_create_task = MagicMock()
@@ -2002,10 +2002,10 @@ async def test_mqtt_status_stale():
 
     assert real_api.mqtt_status == "Stale"
 
-    type(api.realtime).last_packet_time = PropertyMock(return_value=now - 30)
+    type(api.realtime).last_data_time = PropertyMock(return_value=now - 30)
     assert real_api.mqtt_status == "Running"
 
-    type(api.realtime).last_packet_time = PropertyMock(return_value=0)
+    type(api.realtime).last_data_time = PropertyMock(return_value=0)
     assert real_api.mqtt_status == "Starting"
 
     api.realtime._mqtt_connected.is_set.return_value = False

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1302,6 +1302,7 @@ async def test_mqtt_heartbeat_watchdog():
 
     with patch("custom_components.mysa.mqtt.pingreq", return_value=b'\xc0\x00'):
         assert realtime.last_packet_time == 0
+        assert realtime.last_data_time == 0
 
         with patch("time.time") as mock_time:
             start_time = 1000.0
@@ -1314,10 +1315,52 @@ async def test_mqtt_heartbeat_watchdog():
 
             with patch("asyncio.wait_for", side_effect=mock_wait_timeout):
                 realtime._last_packet_time = start_time
+                realtime._last_data_time = start_time
                 mock_time.return_value = start_time + 601
 
                 with pytest.raises(RuntimeError, match="MQTT silence watchdog triggered"):
                     await realtime._run_mqtt_loop(ws)
+
+
+@pytest.mark.asyncio
+async def test_mqtt_watchdog_fires_despite_live_keepalive():
+    """Regression: watchdog must fire when PINGRESP keeps arriving but no PUBLISH.
+
+    This is the silent-freeze bug: the socket + MQTT keepalive stay alive (PINGRESP
+    refreshes _last_packet_time every ping), but the subscription data stream is dead.
+    The data watchdog must ignore keepalive traffic and still force a reconnect.
+    """
+    hass = MagicMock()
+    realtime = MysaRealtime(hass, AsyncMock(), MagicMock())
+
+    ws = AsyncMock()
+
+    with patch("custom_components.mysa.mqtt.pingreq", return_value=b"\xc0\x00"):
+        with patch("time.time") as mock_time:
+            start_time = 1000.0
+            # Data last arrived at connect time; it never arrives again.
+            realtime._last_data_time = start_time
+            # Keepalive is healthy: packets keep flowing right up to "now".
+            realtime._last_packet_time = start_time + 601
+
+            # A PINGRESP is always waiting on recv, so the socket looks alive.
+            async def recv_pingresp():
+                mock_time.return_value = start_time + 601  # keepalive "now"
+                realtime._last_packet_time = start_time + 601
+                return b"\xd0\x00"  # PINGRESP
+
+            ws.recv = AsyncMock(side_effect=recv_pingresp)
+
+            async def passthrough_wait_for(coro, timeout=None):
+                return await coro
+
+            with patch("asyncio.wait_for", side_effect=passthrough_wait_for):
+                mock_time.return_value = start_time + 601
+                with pytest.raises(
+                    RuntimeError, match="MQTT silence watchdog triggered"
+                ):
+                    await realtime._run_mqtt_loop(ws)
+
 
 def test_realtime_is_connected():
     """Test is_connected property."""


### PR DESCRIPTION
Closes #23

## Problem

On INF-V1-0 (and any Mysa device), all HA telemetry channels periodically freeze at their last values for hours, while `binary_sensor.*_connection` keeps reporting **connected**. Recovery only happens on a manual `homeassistant.reload_config_entry`. Observed recurrence roughly every 2–2.5 h; during a freeze, *every* channel (ambient/floor temp, humidity, RSSI, free heap, power) stops simultaneously — i.e. transport/subscription-level death, not a per-sensor issue.

## Root cause

`v0.9.2` already has a zombie-connection watchdog in `MysaRealtime._run_mqtt_loop` — but it can never fire in this failure mode.

The watchdog keys off `_last_packet_time`, which is refreshed on **every** inbound frame (`self._last_packet_time = time.time()` after each `ws.recv()`), *including MQTT PINGRESP*. The loop sends a `PINGREQ` every `MQTT_PING_INTERVAL` (25 s); as long as the broker answers pings, `_last_packet_time` is refreshed ~every 25 s **even after the AWS IoT subscription stream has silently stopped delivering PUBLISH messages**. So `time.time() - _last_packet_time` never crosses the 600 s threshold, and the connection is never torn down.

This matches every symptom:
- **Connection sensor "lies":** it reads the device-reported `Connected`/`isConnected` field, which is itself frozen telemetry.
- **All channels freeze together:** no PUBLISH frames are arriving at all.
- **Never self-heals:** PINGRESP keeps the watchdog timer fresh indefinitely.
- WS-level keepalive is disabled (`ping_interval=None` in `connect_websocket`), so MQTT PINGREQ/PINGRESP is the *only* liveness mechanism — and it's exactly what masks the death.

## Fix

Track inbound **PUBLISH** (real device telemetry) separately from any-packet traffic:

- New `_last_data_time`, refreshed **only** when a `PublishPacket` is received (never by PINGRESP/PUBACK), initialised on connect.
- Watchdog now keys off `_last_data_time` with a named constant `MQTT_DATA_TIMEOUT = 600`. A dropped subscription with a live socket is now detected and force-reconnected within ~10 min, regardless of root cause (half-open TCP, broker drop, AWS session/credential expiry).
- `mqtt_status` staleness now measures telemetry (`last_data_time`) instead of keepalive, so `system_health` stops reporting "Running" during a freeze.

Minimal and backward-compatible: `_last_packet_time` and its `last_packet_time` property are retained; a new `last_data_time` property is added.

## Tests

- Updated `test_mqtt_heartbeat_watchdog` to drive `_last_data_time`.
- New `test_mqtt_watchdog_fires_despite_live_keepalive`: PINGRESP keeps arriving on every `recv()` but no PUBLISH ever does — asserts the watchdog still fires. This is the exact scenario the old code missed.
- Updated the `mqtt_status` tests (`test_api.py`) to drive `last_data_time`.

## Validation

- All changed files `py_compile` clean.
- Standalone logic simulation confirms: old (any-packet) watchdog **never** fires under continuous PINGRESP; new (data-only) watchdog fires ~10 min after telemetry stops.
- Deployed to a live HAOS instance (2026.7.0) with an INF-V1-0 + a second Mysa: integration loads clean, telemetry flows, no errors. The multi-hour "does the freeze stop recurring" metric is being monitored over 24–48 h against `binary_sensor` staleness (baseline ~10 stale events/day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)