### PR TITLE
fix: deadband current_temperature to stop floor-sensor state-write storms

### DIFF
--- a/custom_components/mysa/climate.py
+++ b/custom_components/mysa/climate.py
@@ -64,6 +64,15 @@ PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
 
+# Minimum change (in the entity's display unit, °C or °F) before a new
+# current_temperature is reported to Home Assistant. Floor thermistors jitter by
+# ±0.1-0.3 °C every few seconds; without hysteresis every reading is a distinct
+# HA state write (~11k/day for a single entity) even though the state and every
+# meaningful attribute are unchanged. Holding the last reported value until the
+# reading moves by at least this deadband lets HA's identical-state dedup drop
+# the noise while still surfacing real temperature changes.
+CURRENT_TEMP_DEADBAND = 0.5
+
 
 async def async_setup_entry(
     _hass: HomeAssistant,
@@ -135,6 +144,8 @@ class MysaClimate(
         self._attr_unique_id = device_id
         self._pending_updates: dict[str, dict[str, Any]] = {}
         self._has_logged_sensortemp_warning = False
+        # Last current_temperature value reported to HA, for deadband hysteresis.
+        self._ct_reported: float | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -241,11 +252,29 @@ class MysaClimate(
         if val is not None:
             try:
                 f_val = float(val)
-                # Apply conversion
-                return self._convert_to_display(f_val if f_val != 0 else None)
+                # Apply conversion, then a deadband to suppress sensor noise.
+                display = self._convert_to_display(f_val if f_val != 0 else None)
+                return self._apply_current_temp_deadband(display)
             except (ValueError, TypeError):
                 pass
         return None
+
+    def _apply_current_temp_deadband(self, value: float | None) -> float | None:
+        """Hold the last reported current_temperature until it moves meaningfully.
+
+        Floor thermistors report a marginally different value every few seconds.
+        Forwarding each one makes HA record a new state ~11k times/day even
+        though nothing meaningful changed. We only advance the reported value
+        once it moves by at least CURRENT_TEMP_DEADBAND from the value we last
+        reported, so HA's identical-state dedup drops the noise. A value of None
+        (sensor unavailable) is passed through and does not update the baseline.
+        """
+        if value is None:
+            return None
+        last = self._ct_reported
+        if last is None or abs(value - last) >= CURRENT_TEMP_DEADBAND:
+            self._ct_reported = value
+        return self._ct_reported
 
     @property
     def target_temperature(self) -> float | None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -383,6 +383,41 @@ class TestMysaClimateInfloor:
         }
         assert infloor_entity.current_temperature == 22.0
 
+    @pytest.mark.asyncio
+    async def test_current_temperature_deadband_suppresses_noise(
+        self, hass, mock_coordinator, infloor_entity
+    ):
+        """Floor-sensor jitter below the deadband must not change the reported value.
+
+        Regression for excessive HA state writes: the floor thermistor jitters by
+        ±0.1-0.3 °C every few seconds, which produced ~11k state writes/day. The
+        reported current_temperature must hold until the reading moves by at least
+        CURRENT_TEMP_DEADBAND, so HA's identical-state dedup drops the noise.
+        """
+        from custom_components.mysa.climate import CURRENT_TEMP_DEADBAND
+
+        assert CURRENT_TEMP_DEADBAND == 0.5
+
+        def read(infloor: float | None) -> float | None:
+            mock_coordinator.data = {"infloor1": {"Infloor": infloor, "SensorMode": 1}}
+            return infloor_entity.current_temperature
+
+        # First real reading is reported as-is.
+        assert read(23.4) == 23.4
+        # Sub-deadband jitter holds the last reported value (no HA write).
+        assert read(23.5) == 23.4
+        assert read(23.2) == 23.4
+        assert read(23.6) == 23.4  # 0.2 above baseline, still < 0.5
+        # A move of >= deadband advances the reported value.
+        assert read(23.9) == 23.9  # exactly 0.5 above baseline
+        assert read(24.1) == 23.9  # holds around the new baseline
+        # A downward move of >= deadband advances too.
+        assert read(23.4) == 23.4  # 0.5 below 23.9
+        # None (sensor unavailable) passes through without corrupting the baseline.
+        mock_coordinator.data = {"infloor1": {"SensorMode": 1}}
+        assert infloor_entity.current_temperature is None
+        assert read(23.5) == 23.4  # baseline preserved across the None
+
 
 class TestMysaClimateActions:
     """Test MysaClimate actions."""


### PR DESCRIPTION
Closes #25

## Problem

`climate.*` for an INF-V1 (in-floor) device records ~11,000 HA states/day (~80k/week) even though the entity state never changes. Measured from 1 h of recorder history on a live device:

- **448 recorded states in 1 hour** (~10,750/day), `state` = `off` on all of them.
- `current_temperature` changed on **443/448** points, cycling `22.8 … 23.6 °C` — pure ±0.1–0.3 °C floor-thermistor jitter at 0.1 °C resolution.
- Every other attribute (setpoint, `hvac_action`, humidity) was stable.

So each WebSocket push (~5–10 s) writes a new state solely because the raw floor reading moved 0.1 °C, bloating the recorder DB.

## Fix

`MysaClimate.current_temperature` now applies a **deadband with hysteresis**: it holds the last reported value until the reading moves by at least `CURRENT_TEMP_DEADBAND` (0.5 °C). Since the state and all other attributes are unchanged, HA's identical-state dedup then drops the no-op writes.

- **Debounce, not a source change.** Floor temperature stays the reported `current_temperature` in Floor Mode — semantically correct, since that's what the device regulates. (Switching to air temp would misrepresent the thermostat.)
- Applied via the shared base entity, so it benefits all Mysa climate types.
- `None` (sensor unavailable) passes through and does not corrupt the baseline.

## Impact (replaying the fix over the captured 1 h data)

| deadband | writes/h | /day | reduction |
|---|---|---|---|
| none (current) | 448 | ~10,750 | — |
| 0.2 °C | 10 | ~240 | 97.8% |
| **0.5 °C (this PR)** | **2** | **~48** | **99.6%** |

## Tests

Adds `test_current_temperature_deadband_suppresses_noise`: drives a noisy floor sequence through the deadband and asserts sub-threshold jitter holds the reported value, a ≥0.5 °C move (up or down) advances it, and `None` passes through without corrupting the baseline. Existing `current_temperature` tests are unaffected (their steps are all ≥0.5 °C).

## Notes

The 0.5 °C threshold is a module constant; a future enhancement could expose it via the options flow if per-user tuning is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
