### PR TITLE
Improve Vertical and Horizontal swings support

### DIFF
--- a/custom_components/mysa/climate.py
+++ b/custom_components/mysa/climate.py
@@ -50,6 +50,7 @@ from .const import (
     AC_KEY_SWING_V_TOGGLE,
     AC_KEY_SWING_V_ON,
     AC_KEY_SWING_V_OFF,
+    AC_KEY_SWING_K,
     AC_MODE_AUTO,
     AC_MODE_COOL,
     AC_MODE_DRY,
@@ -671,6 +672,13 @@ class MysaACClimate(MysaClimate):
                 for mode in ["off", "auto"]:
                     if mode not in self._supported_swing_modes:
                         self._supported_swing_modes.append(mode)
+
+        # Discovery via AC_KEY_SWING_K is a special case. It supports "auto", but it doesn't respond to the "off" mode
+        if AC_KEY_SWING_K in keys:
+            # If the vertical swing keyID is present, provide basic modes
+            for mode in ["vertical", "auto"]:
+                if mode not in self._supported_swing_modes:
+                    self._supported_swing_modes.append(mode)
 
         # Sort the final list
         self._supported_swing_modes.sort(

--- a/custom_components/mysa/climate.py
+++ b/custom_components/mysa/climate.py
@@ -676,7 +676,7 @@ class MysaACClimate(MysaClimate):
         # Discovery via AC_KEY_SWING_K is a special case. It supports "auto", but it doesn't respond to the "off" mode
         if AC_KEY_SWING_K in keys:
             # If the vertical swing keyID is present, provide basic modes
-            for mode in ["vertical", "auto"]:
+            for mode in ["still", "auto"]:
                 if mode not in self._supported_swing_modes:
                     self._supported_swing_modes.append(mode)
 

--- a/custom_components/mysa/climate.py
+++ b/custom_components/mysa/climate.py
@@ -47,7 +47,9 @@ from .const import (
     AC_KEY_FAN_HIGH,
     AC_KEY_FAN_LOW,
     AC_KEY_FAN_MEDIUM,
+    AC_KEY_SWING_V_TOGGLE,
     AC_KEY_SWING_V_ON,
+    AC_KEY_SWING_V_OFF,
     AC_MODE_AUTO,
     AC_MODE_COOL,
     AC_MODE_DRY,
@@ -663,8 +665,9 @@ class MysaACClimate(MysaClimate):
         # Discovery via KeyIDs for swing if missing in modes
         keys = self._supported_caps.get("keys", [])
         if not self._supported_swing_modes and keys:
-            if AC_KEY_SWING_V_ON in keys:
-                # If vertical swing key is present, provide core modes
+            swing_keys = [AC_KEY_SWING_V_TOGGLE, AC_KEY_SWING_V_ON, AC_KEY_SWING_V_OFF]
+            if any(swing_key in swing_keys for swing_key in keys):
+                # If any of the vertical swing keyIDs is present, provide core modes
                 for mode in ["off", "auto"]:
                     if mode not in self._supported_swing_modes:
                         self._supported_swing_modes.append(mode)

--- a/custom_components/mysa/const.py
+++ b/custom_components/mysa/const.py
@@ -72,6 +72,7 @@ AC_FAN_MODES = {
 AC_FAN_MODES_REVERSE = {v: k for k, v in AC_FAN_MODES.items()}
 
 # KeyIDs for swing discovery
+AC_KEY_SWING_V_TOGGLE = 12
 AC_KEY_SWING_V_ON = 39
 AC_KEY_SWING_V_OFF = 40
 

--- a/custom_components/mysa/const.py
+++ b/custom_components/mysa/const.py
@@ -79,7 +79,7 @@ AC_KEY_SWING_K = 47
 
 # Swing Positions (vertical and horizontal share the same values)
 AC_SWING_OFF = 0
-AC_SWING_VERTICAL = 1
+AC_SWING_STILL = 1
 AC_SWING_AUTO = 2
 AC_SWING_POSITION_1 = 3  # Top
 AC_SWING_POSITION_2 = 4
@@ -93,7 +93,7 @@ AC_SWING_HORIZONTAL = 10  # Moved out of vertical sequence
 # Home Assistant swing mode names (vertical)
 AC_SWING_MODES = {
     AC_SWING_OFF: "off",
-    AC_SWING_VERTICAL: "vertical",
+    AC_SWING_STILL: "still",
     AC_SWING_AUTO: "auto",
     AC_SWING_POSITION_1: "top",
     AC_SWING_POSITION_2: "upper",

--- a/custom_components/mysa/const.py
+++ b/custom_components/mysa/const.py
@@ -75,6 +75,7 @@ AC_FAN_MODES_REVERSE = {v: k for k, v in AC_FAN_MODES.items()}
 AC_KEY_SWING_V_TOGGLE = 12
 AC_KEY_SWING_V_ON = 39
 AC_KEY_SWING_V_OFF = 40
+AC_KEY_SWING_K = 47
 
 # Swing Positions (vertical and horizontal share the same values)
 AC_SWING_OFF = 0

--- a/custom_components/mysa/select.py
+++ b/custom_components/mysa/select.py
@@ -51,11 +51,19 @@ async def async_setup_entry(
     for device_id, device_data in devices.items():
         # Add horizontal swing select only for AC devices
         if api.is_ac_device(device_id):
-            entities.append(
-                MysaHorizontalSwingSelect(
-                    coordinator, device_id, device_data, api, entry
-                )
+            # Add horizontal swing select entity only if the device supports horizontal swing
+            supported_caps = device_data.get("SupportedCaps", {})
+            modes = supported_caps.get("modes", {})
+            supports_horizontal_swing = any(
+                mode_caps.get("horizontalSwing") for mode_caps in modes.values()
             )
+
+            if supports_horizontal_swing:
+                entities.append(
+                    MysaHorizontalSwingSelect(
+                        coordinator, device_id, device_data, api, entry
+                    )
+                )
 
         # Add sensor mode select for In-Floor devices
         model = str(device_data.get("Model", ""))

--- a/custom_components/mysa/select.py
+++ b/custom_components/mysa/select.py
@@ -124,10 +124,11 @@ class MysaHorizontalSwingSelect(
                     name = AC_HORIZONTAL_SWING_MODES.get(pos)
                     if name and name not in self._options:
                         self._options.append(name)
+
+                # Fallback to defaults if not found
+                if not self._options:
+                    self._options = list(AC_HORIZONTAL_SWING_MODES.values())
                 break
-        # Fallback to defaults if not found
-        if not self._options:
-            self._options = list(AC_HORIZONTAL_SWING_MODES.values())
 
         _LOGGER.debug(
             "Horizontal swing options for %s: %s", self._device_id, self._options


### PR DESCRIPTION
Add support for SWING_K as a discovery keyID for Vertical swing support,
Clarify what "vertical" mode usage (rename for proper meaning),
Validate if the Horizontal swing selectable menu should be available.

Based on codeset ID 671 for a Fujitsu Halcyon HVAC unit.