### PR TITLE
Fix legacy BB and INF telemetry refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A native cloud integration for Mysa devices in Home Assistant. Uses the official
 ## Known Limitations
 
 - **Cloud Dependency**: This integration relies on the Mysa cloud API. It will not work without an internet connection.
-- **Polling Fallback**: If the MQTT WebSocket connection drops, the integration falls back to HTTP polling every 120 seconds.
+- **Polling Fallback**: HTTP state refresh runs independently of MQTT traffic, with a 120-second pause between refreshes and a 90-second timeout. This also refreshes devices that stop reporting measurements while the MQTT connection remains open.
 - **AWS Authentication Stack**: The `boto3` and `pycognito` dependencies handle AWS Cogntio/SigV4 authentication. While all blocking calls are safely wrapped in async executors so they do not block the Home Assistant event loop, they cannot directly reuse the Home Assistant core `aiohttp` web session object.
 - **Simulated Energy**: The energy consumption is an estimate based on your heater's wattage and duty cycle. Unless the device explicitly reports real electrical `Current` (like the Baseboard V1 and V2 Full), the energy usage is not 100% accurate.
 - **Batch Data**: Batch history is currently used strictly for debugging purposes and is disabled in the main integration to avoid database collisions with standard real-time updates.

--- a/custom_components/mysa/__init__.py
+++ b/custom_components/mysa/__init__.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -71,8 +70,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry[MysaData]) -
         _LOGGER,
         name="mysa_integration",
         update_method=async_update_data,
-        # Slower polling since MQTT provides real-time updates
-        update_interval=timedelta(seconds=120),
+        # MQTT pushes reset coordinator timers; use an independent loop below.
+        update_interval=None,
         config_entry=entry,
     )
 
@@ -166,6 +165,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry[MysaData]) -
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    async def async_poll_state() -> None:
+        """Refresh HTTP state independently of incoming MQTT traffic."""
+        while True:
+            await asyncio.sleep(120)
+            try:
+                async with asyncio.timeout(90):
+                    await coordinator.async_refresh()
+            except TimeoutError:
+                _LOGGER.warning("Periodic Mysa HTTP refresh exceeded 90 seconds")
+
+    poll_task = hass.async_create_background_task(
+        async_poll_state(), name="mysa_http_poll"
+    )
+    entry.async_on_unload(poll_task.cancel)
 
     # Monitor for device changes during polling and remove stale devices
     previous_devices: set[str] = (

--- a/custom_components/mysa/client.py
+++ b/custom_components/mysa/client.py
@@ -473,11 +473,13 @@ class MysaClient:
         else:
             self.devices = {}
 
-        # Round 2: Batch Telemetry (ST1 / All Devices)
-        # Now that self.devices is populated, we can target them.
-        # We query ALL devices to allow the backend to decide what data to return.
-        # This supports ST1 and potentially other device types discovered later.
-        target_ids = list(self.devices.keys())
+        # BB/INF batch readings can be days older than /devices/state.
+        # Preserve the existing batch path for other device families.
+        target_ids = [
+            device_id
+            for device_id, device in self.devices.items()
+            if not str(device.get("Model", "")).upper().startswith(("BB-", "INF-"))
+        ]
         st1_states = {}
 
         if target_ids:
@@ -500,6 +502,9 @@ class MysaClient:
     ) -> None:
         """Merge ST1 batch telemetry into result states."""
         for device_id, device_payload in st1_batch.items():
+            model = str(self.devices.get(device_id, {}).get("Model", "")).upper()
+            if model.startswith(("BB-", "INF-")):
+                continue
             if device_id not in result_states:
                 # Provide base if missing from standard poll
                 result_states[device_id] = self.devices.get(device_id, {}).copy()

--- a/custom_components/mysa/device.py
+++ b/custom_components/mysa/device.py
@@ -182,7 +182,9 @@ class MysaDeviceLogic:
         if current_val is not None:
             state["Current"] = current_val
         # Handle 'temperature' and 'humidity' variants
-        temp_val = get_v(["currentTemperature", "ambTemp", "current_temp_raw"])
+        temp_val = get_v(
+            ["currentTemperature", "ambTemp", "current_temp_raw", "CorrectedTemp"]
+        )
         if temp_val is not None:
             # Most devices send C*100, some send C
             f_temp = float(temp_val)
@@ -191,7 +193,9 @@ class MysaDeviceLogic:
             else:
                 state["current_temp"] = f_temp
 
-        hum_val = get_v(["currentHumidity", "humidity", "hum", "relativeHumidity"])
+        hum_val = get_v(
+            ["currentHumidity", "humidity", "hum", "relativeHumidity", "Humidity"]
+        )
         if hum_val is not None:
             state["current_humidity"] = float(hum_val)
         hs_val = get_v(["hs", "HeatSink"])

--- a/tests/test_legacy_refresh.py
+++ b/tests/test_legacy_refresh.py
@@ -1,0 +1,193 @@
+"""Regression coverage for frozen BB/INF measurements and HTTP polling."""
+
+import asyncio
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+
+from custom_components.mysa import async_setup_entry
+from custom_components.mysa.client import MysaClient
+from custom_components.mysa.device import MysaDeviceLogic
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("humidity", [0, 57])
+def test_legacy_measurements(nested, humidity):
+    """Long-form measurements normalize without changing floor control fields."""
+    state = {
+        "CorrectedTemp": 23.25,
+        "Humidity": humidity,
+        "SensorMode": 1,
+        "Infloor": 26.5,
+        "SetPoint": 18,
+        "Mode": 1,
+    }
+    if nested:
+        for key in ("CorrectedTemp", "Humidity"):
+            state[key] = {"v": state[key], "t": 200}
+    MysaDeviceLogic.normalize_state(state)
+    assert state["current_temp"] == 23.25
+    assert state["current_humidity"] == humidity
+    assert (
+        state["SensorMode"],
+        state["Infloor"],
+        state["SetPoint"],
+        state["Mode"],
+    ) == (1, 26.5, 18, 1)
+
+
+def test_existing_measurement_aliases_keep_precedence():
+    """Adding legacy fallbacks does not change existing short-form behavior."""
+    state = {
+        "ambTemp": {"v": 2150},
+        "hum": 0,
+        "CorrectedTemp": 19,
+        "Humidity": 57,
+    }
+    MysaDeviceLogic.normalize_state(state)
+    assert state["current_temp"] == 21.5
+    assert state["current_humidity"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mixed", [False, True])
+async def test_http_keeps_live_legacy_readings(hass, mixed):
+    """Stale batch data cannot mask BB/INF values, including in mixed accounts."""
+    devices = {
+        "bb1": {"Model": "BB-V1-0"},
+        "bb2": {"Model": "BB-V2-0"},
+        "floor": {"Model": "INF-V1-0"},
+    }
+    if mixed:
+        devices.update({"st": {"Model": "ST-V1-0"}, "ac": {"Model": "AC-V1-0"}})
+    live = {
+        key: {"CorrectedTemp": {"v": 23.25, "t": 200}, "Humidity": {"v": 57, "t": 200}}
+        for key in devices
+    }
+    stale_batch = {
+        key: {
+            "data": {
+                "latestTelemetry": {
+                    "timestamp": 100,
+                    "reading": {"roomTemperature": 19, "humidity": 40},
+                }
+            }
+        }
+        for key in devices
+    }
+
+    def response(url, **_kwargs):
+        payload = (
+            {"DeviceStatesObj": deepcopy(live)}
+            if url.endswith("/devices/state")
+            else {"DevicesObj": devices}
+        )
+        result = MagicMock()
+        result.raise_for_status.return_value = None
+        result.json = AsyncMock(return_value=payload)
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=result)
+        context.__aexit__ = AsyncMock(return_value=False)
+        return context
+
+    session = MagicMock()
+    session.get.side_effect = response
+    client = MysaClient(hass, "test@example.com", "test-password", websession=session)
+    client._user_obj = MagicMock()
+    with (
+        patch.object(client, "_get_auth_headers", AsyncMock(return_value={})),
+        patch.object(client, "fetch_homes", AsyncMock()),
+        # Include unsolicited BB/INF entries to exercise the merge safeguard too.
+        patch.object(
+            client, "get_st1_state", AsyncMock(return_value=stale_batch)
+        ) as batch,
+    ):
+        result = await client.get_state()
+    for key in ("bb1", "bb2", "floor"):
+        assert result[key]["current_temp"] == 23.25
+        assert result[key]["current_humidity"] == 57
+        assert "roomTemperature" not in result[key]
+    if mixed:
+        batch.assert_awaited_once_with(["st", "ac"])
+        for key in ("st", "ac"):
+            assert result[key]["roomTemperature"] == 19
+            assert result[key]["current_humidity"] == 40
+    else:
+        batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout_first", [False, True])
+async def test_poll_survives_pushes_and_stops_on_unload(hass, timeout_first, caplog):
+    """MQTT pushes cannot postpone HTTP polling; timeout and unload are handled."""
+    entry = MagicMock()
+    entry.entry_id = "legacy_refresh_test"
+    entry.data = {"username": "test@example.com", "password": "test-password"}
+    entry.options = {}
+    entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+    api = MagicMock()
+    api.states = {"bb1": {"current_temp": 23.25}}
+    api.authenticate = AsyncMock()
+    api.get_devices = AsyncMock()
+    api.get_state = AsyncMock(return_value=api.states)
+    api.start_mqtt_listener = AsyncMock()
+    sleeps = asyncio.Queue()
+    ticks = asyncio.Semaphore(0)
+    tasks = []
+    create_task = hass.async_create_background_task
+
+    async def controlled_sleep(delay):
+        await sleeps.put(delay)
+        await ticks.acquire()
+
+    def capture_task(coro, **kwargs):
+        task = create_task(coro, **kwargs)
+        tasks.append(task)
+        return task
+
+    # Replace only the integration's clock, leaving HA and pytest's loop intact.
+    clock = SimpleNamespace(
+        sleep=controlled_sleep, timeout=asyncio.timeout, create_task=asyncio.create_task
+    )
+    with (
+        patch("custom_components.mysa.MysaApi", return_value=api),
+        patch(
+            "custom_components.mysa.async_get_clientsession", return_value=MagicMock()
+        ),
+        patch("custom_components.mysa.asyncio", clock),
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()),
+        patch.object(hass, "async_create_background_task", side_effect=capture_task),
+    ):
+        try:
+            assert await async_setup_entry(hass, entry)
+            assert await asyncio.wait_for(sleeps.get(), 1) == 120
+            coordinator = entry.runtime_data.coordinator
+            side_effect = [TimeoutError(), None] if timeout_first else [None, None]
+            with patch.object(
+                coordinator, "async_refresh", AsyncMock(side_effect=side_effect)
+            ) as refresh:
+                for poll in range(2):
+                    for push in range(12):
+                        with patch(
+                            "custom_components.mysa.time.time",
+                            return_value=1000 + poll * 120 + push,
+                        ):
+                            await api.coordinator_callback()
+                    assert refresh.await_count == poll
+                    ticks.release()
+                    assert await asyncio.wait_for(sleeps.get(), 1) == 120
+                    assert refresh.await_count == poll + 1
+            if timeout_first:
+                assert "Periodic Mysa HTTP refresh exceeded 90 seconds" in caplog.text
+            # Exercise the cancellation hook registered with the config entry.
+            entry.async_on_unload.assert_any_call(tasks[0].cancel)
+            tasks[0].cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await tasks[0]
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
## Summary

This addresses the frozen temperature/humidity symptom reported in #12 without changing its MQTT timestamp filter.

- Run the 120-second HTTP refresh independently from MQTT state pushes. `DataUpdateCoordinator.async_set_updated_data()` reschedules its update interval, so frequent MQTT traffic could indefinitely postpone the previous HTTP refresh.
- Do not merge `latestTelemetry` batch data into BB and INF devices. In affected installations that batch data was older than `/devices/state` and overwrote fresh measurements. The existing ST/AC batch path is preserved.
- Normalize the legacy `CorrectedTemp` and `Humidity` fields when they are the only available current measurements.
- Document the polling behavior and add regression coverage.

## Validation

- Added 9 regression cases for legacy aliases, stale batch precedence, mixed BB/INF/ST/AC inventory behavior, periodic refresh despite MQTT pushes, timeout handling, and unload cancellation.
- The targeted tests pass locally against Home Assistant core: `9 passed`.
- This was deployed on a mixed legacy BB-V1, BB-V2, and INF-V1 installation and the temperature/humidity measurements continued to update after startup; thermostat control and In-Floor settings were preserved.

## Scope and follow-up

This is related to #12, but it does not alter the MQTT timestamp validation discussed there. It therefore should not automatically close that issue. The Linux CI remains the final full-suite validation.